### PR TITLE
refactor: Replace ex_cli with OptionParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,35 @@ $ mix escript.install
 List all packages on Hex that depend on `circuits_i2c`.
 
 ```bash
-$ hexquery dependents circuits_i2c
+$ hexquery --depends circuits_i2c
 ads1115
 atecc508a
+breadboard
+hdc_1000
 hts221
+ina219
+mpl3115a2
+oled
+pca9641
+sgp30
+wafer
 ```
 
-Now search Hex for any packages that depend on `circuits_i2c` and contain "sensor" somewhere in their description.
+List all packages on Hex that depend on `circuits_i2c` with their descriptions.
 
 ```bash
-$ hexquery dependents circuits_i2c --containing "sensor"
-hts221
+$ hexquery --depends circuits_i2c --verbose
+ads1115: Interact with ADS1115 Analog-to-Digital Chips
+atecc508a: Elixir interface for the ATECC508A
+breadboard: An helper library to 'breadboarding' with Elixir with a single-board computer using `Elixir Circuits`
+hdc_1000: I2C interface to HDC1000 sensor
+hts221: An Elixir library for working with the HTS221 sensor
+ina219: Provides a driver for INA219-based voltage and current sensors connected via I2C
+mpl3115a2: Driver for the MPL3115A2 altimeter connected via I2C.
+oled: OLED is a library to manage the monochrome OLED screen based on chip SSD1306. Implements a Scenic driver but also set of graphic primitves to work standalone.
+pca9641: Driver for PCA9641 2-channel I2C bus master arbiter chip
+sgp30: Interface with SGP30 gas sensor in Elixir
+wafer: Wafer is an Elixir library to make writing drivers for i2c and SPI connected peripherals and interacting with GPIO pins easier.
 ```
 
-Replace "sensor" with any quoted search string you wish to filter the resulting package list by. The search only applies to the contents of the description field in the meta section of the package JSON.
+Package descriptions are stripped of newline symbols so that grepping output for search strings is easier.

--- a/lib/hex_query.ex
+++ b/lib/hex_query.ex
@@ -1,47 +1,37 @@
-defmodule HexQuery do
-  use ExCLI.DSL, escript: true
+defmodule HexQuery.CLI do
+  def main(argv) do
+    case OptionParser.parse(argv, switches: [depends: :string, verbose: :boolean]) do
+      {[depends: package], [], []} -> depends(package, false)
+      {[depends: package, verbose: true], [], []} -> depends(package, true)
+      _ -> help()
+    end
+  end
 
-  name "hexquery"
-  description "Query Hex.pm"
-  long_description ~s"""
-  A CLI tool for discovering Elixir/Erlang libraries on Hex
-  """
+  def help() do
+    IO.puts "Usage: hexquery --depends <package> [--verbose]"
+  end
 
-  option :verbose, count: true, aliases: [:v]
+  def depends(package, verbose) do
+    HTTPoison.start
 
-  command :dependents do
-    aliases [:children]
-    description "List package dependents"
-    long_description """
-    Lists all the packages in Hex that depend on a given package
-    """
+    url = "https://hex.pm/api/packages?search=depends%3A#{package}"
 
-    argument :package
-    option :containing, help: "a description search string to filter by"
-
-    run context do
-      HTTPoison.start
-
-      url = "https://hex.pm/api/packages?search=depends%3A#{context.package}"
-
-      case HTTPoison.get(url) do
-        {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-          body
-          |> Jason.decode!
-          |> Enum.filter(fn(package) ->
-                if search_string = context[:containing] do
-                  description = package["meta"]["description"]
-                  String.contains?(description, search_string)
-                else
-                  true
-                end
-             end)
-          |> Enum.map(fn(package) -> IO.puts package["name"] end)
-        {:ok, %HTTPoison.Response{status_code: 404}} ->
-          IO.puts "Not found :("
-        {:error, %HTTPoison.Error{reason: reason}} ->
-          IO.inspect reason
-      end
+    case HTTPoison.get(url) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        body
+        |> Jason.decode!
+        |> Enum.map(fn(package) ->
+          case verbose do
+            false -> IO.puts package["name"]
+            true ->
+              desc = String.replace(package["meta"]["description"], ~r/\r|\n/, " ")
+              IO.puts "#{package["name"]}: #{desc}"
+          end
+        end)
+      {:ok, %HTTPoison.Response{status_code: 404}} ->
+        IO.puts "Error: 404 Not Found"
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        IO.inspect reason
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,27 +4,21 @@ defmodule HexQuery.MixProject do
   def project do
     [
       app: :hexquery,
-      version: "0.1.0",
-      elixir: "~> 1.9",
-      start_permanent: Mix.env() == :prod,
+      version: "0.1.1",
       deps: deps(),
-      escript: [main_module: HexQuery]
-    ]
-  end
-
-  # Run "mix help compile.app" to learn about applications.
-  def application do
-    [
-      extra_applications: [:logger]
+      escript: escript()
     ]
   end
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_cli, "~> 0.1.6"},
       {:httpoison, "~> 1.6.2"},
       {:jason, "~> 1.1.2"}
     ]
+  end
+
+  def escript do
+    [main_module: HexQuery.CLI]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,5 @@
 %{
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "ex_cli": {:hex, :ex_cli, "0.1.6", "30f97ef0751c75863c669cf34ebb689a5a3ebf9dafd2e73739f173fbd7561a53", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.2", "07e33c794f8f8964ee86cebec1a8ed88db5070e52e904b8f12209773c1036085", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.5", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.6.2", "ace7c8d3a361cebccbed19c283c349b3d26991eff73a1eaaa8abae2e3c8089b6", [:mix], [{:hackney, "~> 1.15 and >= 1.15.2", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
I am dissatisfied with `ex_cli` an have replaced it with Elixir's built-in `OptionParser`.